### PR TITLE
Document CI build script using Gradle wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ Proyecto Android (Kotlin + Jetpack Compose) listo para CI y pruebas automáticas
 - minSdk: 26
 
 ## Cómo compilar en CI/local (sin Android Studio)
+El script `tools/ci-build.sh` encapsula los pasos que ejecuta el pipeline de CI
+usando el Gradle wrapper incluido en el repositorio. Asegúrate de tener instalado
+el Android SDK requerido (puedes guiarte por el workflow de GitHub Actions) y
+luego ejecuta:
+
 ```bash
-# Instalar Android SDK (ver workflow o tools/ci-build.sh)
 ./tools/ci-build.sh
 ```
 

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve repository root relative to this script
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Ensure the Gradle wrapper is executable
+chmod +x gradlew
+
+# Run the standard build and lint tasks used in CI
+./gradlew --stacktrace \
+  clean \
+  lint \
+  test \
+  assemble


### PR DESCRIPTION
## Summary
- add a reusable tools/ci-build.sh helper that runs lint, tests, and assemblies via the Gradle wrapper
- clarify README instructions for running the CI build locally with the helper script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db483969d4832e9ae176f350ed8279