### PR TITLE
Use string resource for home greeting

### DIFF
--- a/app/src/androidTest/java/com/aforos/app/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/aforos/app/MainActivityTest.kt
@@ -12,6 +12,7 @@ class MainActivityTest {
 
     @Test
     fun helloTextIsDisplayed() {
-        composeTestRule.onNodeWithText("Hello, Aforos!").assertIsDisplayed()
+        val greeting = composeTestRule.activity.getString(R.string.home_greeting)
+        composeTestRule.onNodeWithText(greeting).assertIsDisplayed()
     }
 }

--- a/app/src/main/java/com/aforos/app/MainActivity.kt
+++ b/app/src/main/java/com/aforos/app/MainActivity.kt
@@ -12,7 +12,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.aforos.app.R
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -35,7 +37,7 @@ fun AforosApp() {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.fillMaxSize()
             ) {
-                Text(text = "Hello, Aforos!")
+                Text(text = stringResource(R.string.home_greeting))
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aforos</string>
+    <string name="home_greeting">Hello, Aforos!</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated home_greeting string resource
- use the string resource in the compose UI
- update the MainActivity test to resolve the greeting from resources

## Testing
- ./gradlew lint test *(fails: Invalid or corrupt jarfile /workspace/Aforos-/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68db5103ece8832e90df54e899ce1f29