### PR TITLE
Add Android CI workflow and artifact packaging

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,31 @@
+name: Android CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Build and test
+        run: tools/ci-build.sh
+
+      - name: Create repository archive
+        run: zip -r Aforos_v9.1_project.zip . -x "*.git*"
+        working-directory: .
+
+      - name: Upload archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Aforos_ci.zip
+          path: Aforos_v9.1_project.zip


### PR DESCRIPTION
## Summary
- add Android CI workflow that runs on pushes and pull requests
- configure Java 17, run the existing CI build script, and produce a repository ZIP artifact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db566b0534832e81e846a4b077394f